### PR TITLE
change list_opened_merge_requests

### DIFF
--- a/src/infra/gitlab_client/mod.rs
+++ b/src/infra/gitlab_client/mod.rs
@@ -25,11 +25,10 @@ impl GitlabClient {
         ci_commit_ref_name: &str,
     ) -> anyhow::Result<MergeRequests> {
         let request = reqwest::Client::new()
-            .get(&format!("{}/api/v4/merge_requests", self.url))
+            .get(&format!("{}/api/v4/projects/{}/merge_requests", self.url, &self.ci_project_id.to_string()))
             .query(&[
                 ("source_branch", ci_commit_ref_name),
                 ("state", "opened"),
-                ("source_project_id", &self.ci_project_id.to_string()),
             ])
             .header("PRIVATE-TOKEN", self.header_authorization())
             .build()?;


### PR DESCRIPTION
due to the fact that "source_branch" doesn't work on all open merge_request, change list_opened_merge_requests to found merge request only on specific project trough project API